### PR TITLE
add overload for single cursor

### DIFF
--- a/src/ZeroEventHubClient/Client.cs
+++ b/src/ZeroEventHubClient/Client.cs
@@ -66,7 +66,7 @@ public class Client
     /// Fetch events from the server
     /// </summary>
     /// <param name="cursor">A single cursor to be used in the request.</param>
-    /// <param name="pageSizeHint">An hint for the page size of the response.
+    /// <param name="pageSizeHint">A hint for the page size of the response.
     /// Set to 0 if the server should decide the size returned</param>
     /// <param name="eventReceiver">An event receiver to handle the received events.</param>
     /// <exception cref="ArgumentException">If cursors are missing.</exception>

--- a/src/ZeroEventHubClient/Client.cs
+++ b/src/ZeroEventHubClient/Client.cs
@@ -78,7 +78,7 @@ public class Client
         IEventReceiver eventReceiver,
         CancellationToken cancellationToken = default)
     {
-        await FetchEvents(new [] {cursor}, pageSizeHint, eventReceiver, new List<string>(), cancellationToken);
+        await FetchEvents(new[] { cursor }, pageSizeHint, eventReceiver, new List<string>(), cancellationToken);
     }
 
     /// <inheritdoc cref="FetchEvents(System.Collections.Generic.IReadOnlyCollection{ZeroEventHubClient.Models.Cursor},int,ZeroEventHubClient.Models.IEventReceiver)"/>

--- a/src/ZeroEventHubClient/Client.cs
+++ b/src/ZeroEventHubClient/Client.cs
@@ -78,8 +78,7 @@ public class Client
         IEventReceiver eventReceiver,
         CancellationToken cancellationToken = default)
     {
-        var cursors = new List<Cursor> { cursor };
-        await FetchEvents(cursors, pageSizeHint, eventReceiver, new List<string>(), cancellationToken);
+        await FetchEvents(new [] {cursor}, pageSizeHint, eventReceiver, new List<string>(), cancellationToken);
     }
 
     /// <inheritdoc cref="FetchEvents(System.Collections.Generic.IReadOnlyCollection{ZeroEventHubClient.Models.Cursor},int,ZeroEventHubClient.Models.IEventReceiver)"/>

--- a/src/ZeroEventHubClient/Client.cs
+++ b/src/ZeroEventHubClient/Client.cs
@@ -62,6 +62,26 @@ public class Client
         await FetchEvents(cursors, pageSizeHint, eventReceiver, new List<string>(), cancellationToken);
     }
 
+    /// <summary>
+    /// Fetch events from the server
+    /// </summary>
+    /// <param name="cursor">A single cursor to be used in the request.</param>
+    /// <param name="pageSizeHint">An hint for the page size of the response.
+    /// Set to 0 if the server should decide the size returned</param>
+    /// <param name="eventReceiver">An event receiver to handle the received events.</param>
+    /// <exception cref="ArgumentException">If cursors are missing.</exception>
+    /// <exception cref="MalformedResponseException">If returned response body could not be parsed.</exception>
+    /// <exception cref="HttpRequestException">If response status code does not indicate success.</exception>
+    public async Task FetchEvents(
+        Cursor cursor,
+        int pageSizeHint,
+        IEventReceiver eventReceiver,
+        CancellationToken cancellationToken = default)
+    {
+        var cursors = new List<Cursor> { cursor };
+        await FetchEvents(cursors, pageSizeHint, eventReceiver, new List<string>(), cancellationToken);
+    }
+
     /// <inheritdoc cref="FetchEvents(System.Collections.Generic.IReadOnlyCollection{ZeroEventHubClient.Models.Cursor},int,ZeroEventHubClient.Models.IEventReceiver)"/>
     /// <param name="headers">An optional sequence containing event headers desired in the response.</param>
     public async Task FetchEvents(

--- a/src/ZeroEventHubClient/ZeroEventHubClient.csproj
+++ b/src/ZeroEventHubClient/ZeroEventHubClient.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <PackageId>ZeroEventHubClient</PackageId>
-        <Version>1.0.1</Version>
+        <Version>1.0.2</Version>
         <Company>Vipps MobilePay</Company>
         <Authors>Vipps MobilePay</Authors>
         <PackageDescription>Broker-less event streaming over HTTP</PackageDescription>


### PR DESCRIPTION
Small overload add, if the caller only use a single cursor. Then let the client wrap that into a list.