### PR TITLE
Replace Moq and FluentAssertions.

### DIFF
--- a/tests/ZeroEventHubClientTests/EventReceiverTests.cs
+++ b/tests/ZeroEventHubClientTests/EventReceiverTests.cs
@@ -57,6 +57,6 @@ public class EventReceiverTests
         eventReceiver.Checkpoints.Count.ShouldBe(6);
 
         var latestCheckpoints = eventReceiver.LatestCheckpoints;
-        latestCheckpoints.ShouldBe(new Cursor[]{new(0, "latest0"), new(1, "latest1")});
+        latestCheckpoints.ShouldBe(new Cursor[] { new(0, "latest0"), new(1, "latest1") });
     }
 }

--- a/tests/ZeroEventHubClientTests/EventReceiverTests.cs
+++ b/tests/ZeroEventHubClientTests/EventReceiverTests.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using FluentAssertions;
+using Shouldly;
 using ZeroEventHubClient.Models;
 
 namespace ZeroEventHubClientTests;
@@ -32,13 +32,13 @@ public class EventReceiverTests
         }
 
         var events = eventReceiver.Events.ToList();
-        events.Count.Should().Be(3);
+        events.Count.ShouldBe(3);
 
         foreach (var id in partitionIds)
         {
-            events[id].PartitionId.Should().Be(id);
-            events[id].Headers.Should().BeSameAs(headers);
-            events[id].Data.Value.Should().Be(testData);
+            events[id].PartitionId.ShouldBe(id);
+            events[id].Headers.ShouldBeSameAs(headers);
+            events[id].Data.Value.ShouldBe(testData);
         }
     }
 
@@ -54,11 +54,11 @@ public class EventReceiverTests
         eventReceiver.Checkpoint(1, "second1");
         eventReceiver.Checkpoint(1, "latest1");
 
-        eventReceiver.Checkpoints.Count.Should().Be(6);
+        eventReceiver.Checkpoints.Count.ShouldBe(6);
 
         var latestCheckpoints = eventReceiver.LatestCheckpoints;
-        latestCheckpoints.Count.Should().Be(2);
-        latestCheckpoints.Should().ContainSingle(cursor => cursor.PartitionId == 0 && cursor.Value == "latest0");
-        latestCheckpoints.Should().ContainSingle(cursor => cursor.PartitionId == 1 && cursor.Value == "latest1");
+        latestCheckpoints.Count.ShouldBe(2);
+        latestCheckpoints.Where(cursor => cursor is { PartitionId: 0, Value: "latest0" }).ShouldHaveSingleItem();
+        latestCheckpoints.Where(cursor => cursor is { PartitionId: 1, Value: "latest1" }).ShouldHaveSingleItem();
     }
 }

--- a/tests/ZeroEventHubClientTests/EventReceiverTests.cs
+++ b/tests/ZeroEventHubClientTests/EventReceiverTests.cs
@@ -57,8 +57,6 @@ public class EventReceiverTests
         eventReceiver.Checkpoints.Count.ShouldBe(6);
 
         var latestCheckpoints = eventReceiver.LatestCheckpoints;
-        latestCheckpoints.Count.ShouldBe(2);
-        latestCheckpoints.Where(cursor => cursor is { PartitionId: 0, Value: "latest0" }).ShouldHaveSingleItem();
-        latestCheckpoints.Where(cursor => cursor is { PartitionId: 1, Value: "latest1" }).ShouldHaveSingleItem();
+        latestCheckpoints.ShouldBe(new Cursor[]{new(0, "latest0"), new(1, "latest1")});
     }
 }

--- a/tests/ZeroEventHubClientTests/ZeroEventHubClientTests.csproj
+++ b/tests/ZeroEventHubClientTests/ZeroEventHubClientTests.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.9.0"/>
+        <PackageReference Include="Shouldly" Version="4.3.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
-        <PackageReference Include="Moq" Version="4.18.4"/>
+        <PackageReference Include="NSubstitute" Version="5.3.0"/>
         <PackageReference Include="xunit" Version="2.4.1"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Because of licensing changes, we're replacing these libraries as follows:

Moq is replaced by NSubstitute
FluentAssertions is replacesd by Shouldly